### PR TITLE
feat: custom OpenAI-compatible API, DashScope Qwen ASR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ src-tauri/target/
 .env
 /.env.bak
 /.mcp.json
+*.dmg

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1667,7 +1666,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1737,7 +1735,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2296,7 +2293,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2337,7 +2333,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2525,7 +2520,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -63,17 +63,50 @@ pub fn request_microphone() -> bool {
 }
 
 #[tauri::command]
-pub async fn validate_api_key(app: AppHandle, api_key: String, provider: String) -> Result<(), String> {
+pub async fn validate_api_key(
+    app: AppHandle,
+    api_key: String,
+    provider: String,
+    custom_base_url: String,
+    model: String,
+) -> Result<(), String> {
     let client = app
         .try_state::<reqwest::Client>()
         .ok_or("HTTP client not initialized")?;
+    let vm = if model.trim().is_empty() {
+        "whisper-1"
+    } else {
+        model.trim()
+    };
     match provider.as_str() {
         "gemini" => crate::transcribe::validate_gemini_api_key(&client, &api_key)
             .await
             .map_err(|e| e.to_string()),
-        _ => crate::transcribe::validate_api_key(&client, &api_key)
-            .await
-            .map_err(|e| e.to_string()),
+        "kimi" => crate::transcribe::validate_openai_compatible_key(
+            &client,
+            "https://api.moonshot.cn/v1",
+            &api_key,
+            vm,
+        )
+        .await
+        .map_err(|e| e.to_string()),
+        "custom" => {
+            let base = custom_base_url.trim();
+            if base.is_empty() {
+                return Err("API base URL is required for custom provider".into());
+            }
+            crate::transcribe::validate_openai_compatible_key(&client, base, &api_key, vm)
+                .await
+                .map_err(|e| e.to_string())
+        }
+        _ => crate::transcribe::validate_openai_compatible_key(
+            &client,
+            "https://api.openai.com/v1",
+            &api_key,
+            vm,
+        )
+        .await
+        .map_err(|e| e.to_string()),
     }
 }
 
@@ -159,9 +192,20 @@ pub async fn retry_transcription(
             .await
             .map_err(|e| e.to_string())?
     } else {
-        transcribe::transcribe_audio(&client, active_key, &settings.model, wav_data, lang)
-            .await
-            .map_err(|e| e.to_string())?
+        let base = crate::settings::openai_compatible_transcription_base(&settings);
+        if settings.provider == "custom" && base.is_empty() {
+            return Err("API base URL is not configured".into());
+        }
+        transcribe::transcribe_openai_compatible(
+            &client,
+            &base,
+            active_key,
+            &settings.model,
+            wav_data,
+            lang,
+        )
+        .await
+        .map_err(|e| e.to_string())?
     };
 
     // Update entry in place (preserves ID and audio_path)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -177,8 +177,12 @@ pub fn run() {
             let recorder = Arc::new(AudioRecorder::new());
             app.manage(recorder.clone());
 
-            // Initialize shared HTTP client
-            let http_client = reqwest::Client::new();
+            // Initialize shared HTTP client (timeouts so Test Connection cannot hang forever)
+            let http_client = reqwest::Client::builder()
+                .connect_timeout(std::time::Duration::from_secs(20))
+                .timeout(std::time::Duration::from_secs(180))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new());
             app.manage(http_client);
 
             // Initialize enigo if accessibility is already granted
@@ -269,6 +273,9 @@ pub fn run() {
             log::info!("App started. Provider: {}, Shortcut: {}", settings.provider, settings.shortcut);
             let active_key_set = if settings.provider == "gemini" {
                 !settings.gemini_api_key.is_empty()
+            } else if settings.provider == "custom" {
+                !settings.api_key.is_empty()
+                    && !settings.custom_api_base_url.trim().is_empty()
             } else {
                 !settings.api_key.is_empty()
             };
@@ -531,6 +538,17 @@ fn stop_and_transcribe(app_handle: &tauri::AppHandle) {
         return;
     }
 
+    let openai_base = settings::openai_compatible_transcription_base(&settings);
+    if settings.provider == "custom" && openai_base.is_empty() {
+        log::error!("Custom API base URL not configured!");
+        close_overlay(app_handle);
+        if let Some(w) = app_handle.get_webview_window("main") {
+            let _ = w.show();
+            let _ = w.set_focus();
+        }
+        return;
+    }
+
     let handle = app_handle.clone();
     let history = history.inner().clone();
     let model = settings.model.clone();
@@ -555,7 +573,15 @@ fn stop_and_transcribe(app_handle: &tauri::AppHandle) {
         let result = if is_gemini {
             transcribe::transcribe_gemini(&http_client, &active_key, &model, wav_data, lang).await
         } else {
-            transcribe::transcribe_audio(&http_client, &active_key, &model, wav_data, lang).await
+            transcribe::transcribe_openai_compatible(
+                &http_client,
+                &openai_base,
+                &active_key,
+                &model,
+                wav_data,
+                lang,
+            )
+            .await
         };
 
         match result {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -9,6 +9,9 @@ pub struct AppSettings {
     pub api_key: String,
     #[serde(default)]
     pub gemini_api_key: String,
+    /// OpenAI-compatible API base (e.g. `https://api.example.com/v1`). Used when `provider` is `custom`.
+    #[serde(default = "default_custom_api_base_url")]
+    pub custom_api_base_url: String,
     #[serde(default = "default_model")]
     pub model: String,
     #[serde(default = "default_language")]
@@ -29,6 +32,9 @@ fn default_provider() -> String {
 fn default_api_key() -> String {
     String::new()
 }
+fn default_custom_api_base_url() -> String {
+    "https://api.openai.com/v1".to_string()
+}
 fn default_model() -> String {
     "gpt-4o-transcribe".to_string()
 }
@@ -48,6 +54,7 @@ impl Default for AppSettings {
             provider: default_provider(),
             api_key: default_api_key(),
             gemini_api_key: String::new(),
+            custom_api_base_url: default_custom_api_base_url(),
             model: default_model(),
             language: default_language(),
             shortcut: default_shortcut(),
@@ -67,6 +74,15 @@ pub fn get_settings() -> AppSettings {
     match std::fs::read_to_string(&path) {
         Ok(content) => serde_json::from_str::<AppSettings>(&content).unwrap_or_default(),
         Err(_) => AppSettings::default(),
+    }
+}
+
+/// Base URL for OpenAI-style `/v1/audio/transcriptions` (no trailing path segment).
+pub fn openai_compatible_transcription_base(settings: &AppSettings) -> String {
+    match settings.provider.as_str() {
+        "kimi" => "https://api.moonshot.cn/v1".to_string(),
+        "custom" => settings.custom_api_base_url.trim().trim_end_matches('/').to_string(),
+        _ => "https://api.openai.com/v1".to_string(),
     }
 }
 

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -2,18 +2,165 @@ use anyhow::{Context, Result};
 use base64::Engine;
 use reqwest::multipart;
 
-/// Validate API key by sending a tiny silent WAV to the transcription endpoint.
-pub async fn validate_api_key(client: &reqwest::Client, api_key: &str) -> Result<()> {
+/// Alibaba DashScope OpenAI-compatible ASR (Qwen3-ASR, etc.) uses `chat/completions` + `input_audio`, not Whisper multipart.
+fn is_dashscope_compatible_asr_base(base_url: &str) -> bool {
+    let lower = base_url.to_ascii_lowercase();
+    lower.contains("dashscope") && lower.contains("compatible-mode")
+}
+
+fn chat_completions_url(base_url: &str) -> String {
+    let b = base_url.trim().trim_end_matches('/');
+    if b.ends_with("/chat/completions") {
+        b.to_string()
+    } else {
+        format!("{}/chat/completions", b)
+    }
+}
+
+/// Normalize user-facing names like `Qwen3-ASR-Flash` to API id `qwen3-asr-flash`.
+fn normalize_qwen_asr_model(model: &str) -> String {
+    let t = model.trim();
+    if t.is_empty() {
+        return "qwen3-asr-flash".to_string();
+    }
+    t.to_ascii_lowercase().replace('_', "-")
+}
+
+fn dashscope_asr_request_body(
+    model: &str,
+    wav_data: &[u8],
+    language: Option<&str>,
+) -> serde_json::Value {
+    let b64 = base64::engine::general_purpose::STANDARD.encode(wav_data);
+    let data_uri = format!("data:audio/wav;base64,{}", b64);
+
+    let mut body = serde_json::json!({
+        "model": normalize_qwen_asr_model(model),
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "input_audio",
+                "input_audio": { "data": data_uri }
+            }]
+        }]
+    });
+
+    if let Some(lang) = language {
+        if lang != "auto" {
+            body.as_object_mut().unwrap().insert(
+                "asr_options".to_string(),
+                serde_json::json!({ "language": lang }),
+            );
+        }
+    }
+
+    body
+}
+
+fn parse_dashscope_chat_completion_text(json: &serde_json::Value) -> Result<String> {
+    if let Some(msg) = json["error"]["message"].as_str() {
+        anyhow::bail!("{}", msg);
+    }
+    let content = &json["choices"][0]["message"]["content"];
+    let text = if let Some(s) = content.as_str() {
+        s.to_string()
+    } else if let Some(arr) = content.as_array() {
+        arr.iter()
+            .filter_map(|p| p["text"].as_str())
+            .collect::<Vec<_>>()
+            .join("")
+    } else {
+        anyhow::bail!("Unexpected chat/completions response shape");
+    };
+    let t = text.trim();
+    if t.is_empty() {
+        anyhow::bail!("Empty transcription in response");
+    }
+    Ok(t.to_string())
+}
+
+async fn transcribe_dashscope_qwen_asr(
+    client: &reqwest::Client,
+    base_url: &str,
+    api_key: &str,
+    model: &str,
+    wav_data: Vec<u8>,
+    language: Option<&str>,
+) -> Result<String> {
+    let url = chat_completions_url(base_url);
+    let body = dashscope_asr_request_body(model, &wav_data, language);
+
+    let resp = client
+        .post(&url)
+        .bearer_auth(api_key)
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .context("Failed to send DashScope ASR request")?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("DashScope API error {}: {}", status, body);
+    }
+
+    let json: serde_json::Value = resp.json().await.context("Failed to parse API response")?;
+    parse_dashscope_chat_completion_text(&json)
+}
+
+fn transcription_endpoint_url(base_url: &str) -> String {
+    let b = base_url.trim().trim_end_matches('/');
+    if b.ends_with("/audio/transcriptions") {
+        b.to_string()
+    } else {
+        format!("{}/audio/transcriptions", b)
+    }
+}
+
+/// Validate API key against an OpenAI-compatible transcription endpoint.
+pub async fn validate_openai_compatible_key(
+    client: &reqwest::Client,
+    base_url: &str,
+    api_key: &str,
+    model: &str,
+) -> Result<()> {
     let wav = generate_silent_wav();
+
+    if is_dashscope_compatible_asr_base(base_url) {
+        let url = chat_completions_url(base_url);
+        let body = dashscope_asr_request_body(model, &wav, None);
+        let resp = client
+            .post(&url)
+            .bearer_auth(api_key)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .context("Network error")?;
+
+        if resp.status() == 401 {
+            anyhow::bail!("Invalid API key");
+        }
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("{}", body);
+        }
+        let json: serde_json::Value = resp.json().await.unwrap_or_default();
+        let _ = parse_dashscope_chat_completion_text(&json)?;
+        return Ok(());
+    }
+
     let file_part = multipart::Part::bytes(wav)
         .file_name("test.wav")
         .mime_str("audio/wav")?;
     let form = multipart::Form::new()
         .part("file", file_part)
-        .text("model", "whisper-1".to_string());
+        .text("model", model.to_string());
 
+    let url = transcription_endpoint_url(base_url);
     let resp = client
-        .post("https://api.openai.com/v1/audio/transcriptions")
+        .post(&url)
         .bearer_auth(api_key)
         .multipart(form)
         .send()
@@ -28,6 +175,11 @@ pub async fn validate_api_key(client: &reqwest::Client, api_key: &str) -> Result
         anyhow::bail!("{}", body);
     }
     Ok(())
+}
+
+/// Validate OpenAI API key (default cloud endpoint).
+pub async fn validate_api_key(client: &reqwest::Client, api_key: &str) -> Result<()> {
+    validate_openai_compatible_key(client, "https://api.openai.com/v1", api_key, "whisper-1").await
 }
 
 /// Generate a minimal valid WAV file (0.5s silence, 16kHz mono 16-bit).
@@ -54,13 +206,27 @@ fn generate_silent_wav() -> Vec<u8> {
     buf
 }
 
-pub async fn transcribe_audio(
+/// Transcribe via OpenAI-compatible `POST .../audio/transcriptions` (multipart).
+pub async fn transcribe_openai_compatible(
     client: &reqwest::Client,
+    base_url: &str,
     api_key: &str,
     model: &str,
     wav_data: Vec<u8>,
     language: Option<&str>,
 ) -> Result<String> {
+    if is_dashscope_compatible_asr_base(base_url) {
+        return transcribe_dashscope_qwen_asr(
+            client,
+            base_url,
+            api_key,
+            model,
+            wav_data,
+            language,
+        )
+        .await;
+    }
+
     let file_part = multipart::Part::bytes(wav_data)
         .file_name("audio.wav")
         .mime_str("audio/wav")?;
@@ -75,8 +241,9 @@ pub async fn transcribe_audio(
         }
     }
 
+    let url = transcription_endpoint_url(base_url);
     let resp = client
-        .post("https://api.openai.com/v1/audio/transcriptions")
+        .post(&url)
         .bearer_auth(api_key)
         .multipart(form)
         .send()
@@ -96,6 +263,24 @@ pub async fn transcribe_audio(
         .to_string();
 
     Ok(text)
+}
+
+pub async fn transcribe_audio(
+    client: &reqwest::Client,
+    api_key: &str,
+    model: &str,
+    wav_data: Vec<u8>,
+    language: Option<&str>,
+) -> Result<String> {
+    transcribe_openai_compatible(
+        client,
+        "https://api.openai.com/v1",
+        api_key,
+        model,
+        wav_data,
+        language,
+    )
+    .await
 }
 
 // ── Google Gemini (generateContent) ─────────────────────────────────

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,10 +21,36 @@ const GEMINI_MODELS = [
   { value: "gemini-3-flash-preview", label: "Gemini 3 Flash" },
   { value: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro" },
 ];
+/** DashScope OpenAI-compatible root (Beijing). */
+const DASHSCOPE_COMPAT_BASE = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+
+/** Kimi / custom provider model dropdown (values sent to API; Rust normalizes Qwen names). */
+const OPENAI_COMPAT_MODEL_OPTIONS: { value: string; label: string }[] = [
+  { value: "Qwen3-ASR-Flash", label: "Qwen3-ASR-Flash" },
+  { value: "qwen3-asr-flash", label: "qwen3-asr-flash" },
+  { value: "whisper-1", label: "whisper-1" },
+  { value: "gpt-4o-transcribe", label: "gpt-4o-transcribe" },
+  { value: "gpt-4o-mini-transcribe", label: "gpt-4o-mini-transcribe" },
+];
+
+const OPENAI_COMPAT_MODEL_KNOWN = new Set(OPENAI_COMPAT_MODEL_OPTIONS.map((o) => o.value));
 const DEFAULT_MODELS: Record<string, string> = {
   openai: "gpt-4o-transcribe",
   gemini: "gemini-3-flash-preview",
+  kimi: "whisper-1",
+  custom: "whisper-1",
 };
+
+function usesGeminiKey(provider: string) {
+  return provider === "gemini";
+}
+
+function apiKeyFieldLabel(provider: string): string {
+  if (provider === "gemini") return "Gemini API Key";
+  if (provider === "kimi") return "Kimi API Key";
+  if (provider === "custom") return "API Key";
+  return "OpenAI API Key";
+}
 
 function displayShortcut(s: string): string {
   if (!s) return defaultHotkey;
@@ -162,7 +188,7 @@ function App() {
   const loadSettings = useCallback(async () => {
     const s = await invoke<AppSettings>("get_settings");
     setSettings(s);
-    const key = s.provider === "gemini" ? s.gemini_api_key : s.api_key;
+    const key = usesGeminiKey(s.provider) ? s.gemini_api_key : s.api_key;
     if (!key) setView("onboarding");
   }, []);
 
@@ -264,12 +290,19 @@ function App() {
     await invoke("save_settings", { settings });
   };
 
-  const testApiKey = async (key: string, provider: string) => {
+  const testApiKey = async () => {
+    if (!settings) return;
+    const key = usesGeminiKey(settings.provider) ? settings.gemini_api_key : settings.api_key;
     if (!key) return;
     setApiKeyStatus("testing");
     setApiKeyError(null);
     try {
-      await invoke("validate_api_key", { apiKey: key, provider });
+      await invoke("validate_api_key", {
+        apiKey: key,
+        provider: settings.provider,
+        customBaseUrl: settings.custom_api_base_url,
+        model: settings.model,
+      });
       setApiKeyStatus("ok");
     } catch (e) {
       setApiKeyStatus("error");
@@ -277,7 +310,7 @@ function App() {
     }
   };
 
-  const activeApiKey = settings ? (settings.provider === "gemini" ? settings.gemini_api_key : settings.api_key) : "";
+  const activeApiKey = settings ? (usesGeminiKey(settings.provider) ? settings.gemini_api_key : settings.api_key) : "";
 
   const formatTime = (ts: number) => {
     const d = new Date(ts * 1000);
@@ -315,7 +348,7 @@ function App() {
 
   // Onboarding
   if (view === "onboarding" && settings) {
-    const canProceed = apiKeyStatus === "ok" && microphoneOk && (isMac ? accessibilityOk : true);
+    const canProceed = apiKeyStatus === "ok" && microphoneOk;
     return (
       <div className="p-6 max-w-md mx-auto">
         <div className="flex flex-col items-center mb-6">
@@ -338,7 +371,11 @@ function App() {
               value={settings.provider}
               onChange={(e) => {
                 const p = e.target.value;
-                setSettings({ ...settings, provider: p, model: DEFAULT_MODELS[p] || "gpt-4o-transcribe" });
+                setSettings({
+                  ...settings,
+                  provider: p,
+                  model: DEFAULT_MODELS[p] ?? "gpt-4o-transcribe",
+                });
                 setApiKeyStatus("untested");
                 setApiKeyError(null);
               }}
@@ -346,9 +383,64 @@ function App() {
               style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
             >
               <option value="openai">OpenAI</option>
-              <option value="gemini">Gemini</option>
+              <option value="gemini">Google Gemini</option>
+              <option value="kimi">Kimi (Moonshot)</option>
+              <option value="custom">Custom (OpenAI-compatible)</option>
             </select>
-            {settings.provider === "gemini" ? (
+            {settings.provider === "custom" && (
+              <>
+                <label className="block text-xs mb-1" style={{ color: "var(--text-secondary)" }}>API base URL</label>
+                <select
+                  value={
+                    settings.custom_api_base_url.trim() === DASHSCOPE_COMPAT_BASE
+                      ? DASHSCOPE_COMPAT_BASE
+                      : "__custom__"
+                  }
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    const nextUrl =
+                      v === "__custom__"
+                        ? settings.custom_api_base_url.trim() === DASHSCOPE_COMPAT_BASE
+                          ? ""
+                          : settings.custom_api_base_url
+                        : v;
+                    setSettings({ ...settings, custom_api_base_url: nextUrl });
+                    setApiKeyStatus("untested");
+                    setApiKeyError(null);
+                  }}
+                  className="w-full px-3 py-2 rounded-lg text-sm outline-none mb-2"
+                  style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
+                >
+                  <option value={DASHSCOPE_COMPAT_BASE}>{DASHSCOPE_COMPAT_BASE}</option>
+                  <option value="__custom__">自定义 URL…</option>
+                </select>
+                {(settings.custom_api_base_url.trim() !== DASHSCOPE_COMPAT_BASE) && (
+                  <input
+                    type="text"
+                    value={settings.custom_api_base_url}
+                    onChange={(e) => {
+                      setSettings({ ...settings, custom_api_base_url: e.target.value });
+                      setApiKeyStatus("untested");
+                      setApiKeyError(null);
+                    }}
+                    placeholder="https://api.example.com/v1"
+                    className="w-full px-3 py-2 rounded-lg text-sm outline-none mb-2 font-mono"
+                    style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
+                  />
+                )}
+                <p className="text-xs mb-2" style={{ color: "var(--text-secondary)" }}>
+                  OpenAI-compatible root; DashScope Qwen ASR uses chat/completions. Other vendors may use /audio/transcriptions.
+                </p>
+              </>
+            )}
+            {settings.provider === "kimi" && (
+              <p className="text-xs mb-2" style={{ color: "var(--text-secondary)" }}>
+                Uses <span className="font-mono text-[11px]">https://api.moonshot.cn/v1</span>. For international keys, choose Custom and set{" "}
+                <span className="font-mono text-[11px]">https://api.moonshot.ai/v1</span>.
+              </p>
+            )}
+            <label className="block text-xs mb-1" style={{ color: "var(--text-secondary)" }}>{apiKeyFieldLabel(settings.provider)}</label>
+            {usesGeminiKey(settings.provider) ? (
               <input
                 type="password"
                 value={settings.gemini_api_key}
@@ -358,7 +450,7 @@ function App() {
                   setApiKeyError(null);
                 }}
                 placeholder="AIza..."
-                className="w-full px-3 py-2 rounded-lg text-sm outline-none"
+                className="w-full px-3 py-2 rounded-lg text-sm outline-none mb-2"
                 style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
               />
             ) : (
@@ -370,20 +462,93 @@ function App() {
                   setApiKeyStatus("untested");
                   setApiKeyError(null);
                 }}
-                placeholder="sk-proj-..."
-                className="w-full px-3 py-2 rounded-lg text-sm outline-none"
+                placeholder={settings.provider === "kimi" ? "Moonshot API key" : settings.provider === "custom" ? "API key" : "sk-proj-..."}
+                className="w-full px-3 py-2 rounded-lg text-sm outline-none mb-2"
                 style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
               />
             )}
+            <label className="block text-xs mb-1" style={{ color: "var(--text-secondary)" }}>Model</label>
+            {settings.provider === "gemini" ? (
+              <select
+                value={settings.model}
+                onChange={(e) => {
+                  setSettings({ ...settings, model: e.target.value });
+                  setApiKeyStatus("untested");
+                  setApiKeyError(null);
+                }}
+                className="w-full px-3 py-2 rounded-lg text-sm outline-none mb-2"
+                style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
+              >
+                {GEMINI_MODELS.map((m) => (
+                  <option key={m.value} value={m.value}>{m.label}</option>
+                ))}
+              </select>
+            ) : settings.provider === "openai" ? (
+              <select
+                value={settings.model}
+                onChange={(e) => {
+                  setSettings({ ...settings, model: e.target.value });
+                  setApiKeyStatus("untested");
+                  setApiKeyError(null);
+                }}
+                className="w-full px-3 py-2 rounded-lg text-sm outline-none mb-2"
+                style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
+              >
+                {OPENAI_MODELS.map((m) => (
+                  <option key={m.value} value={m.value}>{m.label}</option>
+                ))}
+              </select>
+            ) : (
+              <>
+                <select
+                  value={OPENAI_COMPAT_MODEL_KNOWN.has(settings.model) ? settings.model : "__custom__"}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    setSettings({
+                      ...settings,
+                      model:
+                        v === "__custom__"
+                          ? OPENAI_COMPAT_MODEL_KNOWN.has(settings.model)
+                            ? ""
+                            : settings.model
+                          : v,
+                    });
+                    setApiKeyStatus("untested");
+                    setApiKeyError(null);
+                  }}
+                  className="w-full px-3 py-2 rounded-lg text-sm outline-none mb-2"
+                  style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
+                >
+                  {OPENAI_COMPAT_MODEL_OPTIONS.map((m) => (
+                    <option key={m.value} value={m.value}>{m.label}</option>
+                  ))}
+                  <option value="__custom__">自定义模型名…</option>
+                </select>
+                {!OPENAI_COMPAT_MODEL_KNOWN.has(settings.model) && (
+                  <input
+                    type="text"
+                    value={settings.model}
+                    onChange={(e) => {
+                      setSettings({ ...settings, model: e.target.value });
+                      setApiKeyStatus("untested");
+                      setApiKeyError(null);
+                    }}
+                    placeholder="e.g. my-model-id"
+                    className="w-full px-3 py-2 rounded-lg text-sm outline-none mb-2 font-mono"
+                    style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
+                  />
+                )}
+              </>
+            )}
             <button
-              onClick={() => testApiKey(activeApiKey, settings.provider)}
-              disabled={!activeApiKey || apiKeyStatus === "testing"}
+              onClick={() => testApiKey()}
+              disabled={!activeApiKey || apiKeyStatus === "testing" || (settings.provider === "custom" && !settings.custom_api_base_url.trim())}
               className="w-full mt-2 px-3 py-2 rounded-lg text-sm font-medium"
               style={{
                 background: apiKeyStatus === "ok" ? "#34c75920" : "var(--accent)",
                 color: apiKeyStatus === "ok" ? "#34c759" : "white",
-                cursor: !activeApiKey || apiKeyStatus === "testing" ? "not-allowed" : "pointer",
-                opacity: !activeApiKey || apiKeyStatus === "testing" ? 0.5 : 1,
+                cursor: !activeApiKey || apiKeyStatus === "testing" || (settings.provider === "custom" && !settings.custom_api_base_url.trim()) ? "not-allowed" : "pointer",
+                opacity: !activeApiKey || apiKeyStatus === "testing" || (settings.provider === "custom" && !settings.custom_api_base_url.trim()) ? 0.5 : 1,
               }}
             >
               {apiKeyStatus === "testing" ? "Testing..." : apiKeyStatus === "ok" ? "Connected" : "Test Connection"}
@@ -481,17 +646,74 @@ function App() {
             <label className="block text-xs mb-1" style={{ color: "var(--text-secondary)" }}>Provider</label>
             <select value={settings.provider} onChange={(e) => {
               const p = e.target.value;
-              setSettings({ ...settings, provider: p, model: DEFAULT_MODELS[p] || "gpt-4o-transcribe" });
+              setSettings({
+                ...settings,
+                provider: p,
+                model: DEFAULT_MODELS[p] ?? "gpt-4o-transcribe",
+              });
               setApiKeyStatus("untested");
               setApiKeyError(null);
             }} className="w-full px-3 py-2 rounded-lg text-sm outline-none" style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}>
               <option value="openai">OpenAI</option>
-              <option value="gemini">Gemini</option>
+              <option value="gemini">Google Gemini</option>
+              <option value="kimi">Kimi (Moonshot)</option>
+              <option value="custom">Custom (OpenAI-compatible)</option>
             </select>
           </div>
+          {settings.provider === "custom" && (
+            <div>
+              <label className="block text-xs mb-1" style={{ color: "var(--text-secondary)" }}>API base URL</label>
+              <select
+                value={
+                  settings.custom_api_base_url.trim() === DASHSCOPE_COMPAT_BASE
+                    ? DASHSCOPE_COMPAT_BASE
+                    : "__custom__"
+                }
+                onChange={(e) => {
+                  const v = e.target.value;
+                  const nextUrl =
+                    v === "__custom__"
+                      ? settings.custom_api_base_url.trim() === DASHSCOPE_COMPAT_BASE
+                        ? ""
+                        : settings.custom_api_base_url
+                      : v;
+                  setSettings({ ...settings, custom_api_base_url: nextUrl });
+                  setApiKeyStatus("untested");
+                  setApiKeyError(null);
+                }}
+                className="w-full px-3 py-2 rounded-lg text-sm outline-none mb-2"
+                style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
+              >
+                <option value={DASHSCOPE_COMPAT_BASE}>{DASHSCOPE_COMPAT_BASE}</option>
+                <option value="__custom__">自定义 URL…</option>
+              </select>
+              {(settings.custom_api_base_url.trim() !== DASHSCOPE_COMPAT_BASE) && (
+                <input
+                  type="text"
+                  value={settings.custom_api_base_url}
+                  onChange={(e) => {
+                    setSettings({ ...settings, custom_api_base_url: e.target.value });
+                    setApiKeyStatus("untested");
+                    setApiKeyError(null);
+                  }}
+                  placeholder="https://api.example.com/v1"
+                  className="w-full px-3 py-2 rounded-lg text-sm outline-none font-mono mb-1"
+                  style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
+                />
+              )}
+              <p className="text-xs mt-1" style={{ color: "var(--text-secondary)" }}>
+                DashScope Qwen ASR uses chat/completions; other hosts may use /audio/transcriptions.
+              </p>
+            </div>
+          )}
+          {settings.provider === "kimi" && (
+            <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+              Base <span className="font-mono">https://api.moonshot.cn/v1</span>. International: use Custom with <span className="font-mono">https://api.moonshot.ai/v1</span>.
+            </p>
+          )}
           <div>
-            <label className="block text-xs mb-1" style={{ color: "var(--text-secondary)" }}>{settings.provider === "gemini" ? "Gemini API Key" : "OpenAI API Key"}</label>
-            {settings.provider === "gemini" ? (
+            <label className="block text-xs mb-1" style={{ color: "var(--text-secondary)" }}>{apiKeyFieldLabel(settings.provider)}</label>
+            {usesGeminiKey(settings.provider) ? (
               <input type="password" value={settings.gemini_api_key} onChange={(e) => {
                 setSettings({ ...settings, gemini_api_key: e.target.value });
                 setApiKeyStatus("untested");
@@ -502,17 +724,17 @@ function App() {
                 setSettings({ ...settings, api_key: e.target.value });
                 setApiKeyStatus("untested");
                 setApiKeyError(null);
-              }} placeholder="sk-..." className="w-full px-3 py-2 rounded-lg text-sm outline-none" style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }} />
+              }} placeholder={settings.provider === "kimi" ? "Moonshot API key" : settings.provider === "custom" ? "API key" : "sk-..."} className="w-full px-3 py-2 rounded-lg text-sm outline-none" style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }} />
             )}
             <button
-              onClick={() => testApiKey(activeApiKey, settings.provider)}
-              disabled={!activeApiKey || apiKeyStatus === "testing"}
+              onClick={() => testApiKey()}
+              disabled={!activeApiKey || apiKeyStatus === "testing" || (settings.provider === "custom" && !settings.custom_api_base_url.trim())}
               className="w-full mt-1.5 px-3 py-1.5 rounded-lg text-xs font-medium"
               style={{
                 background: apiKeyStatus === "ok" ? "#34c75920" : "var(--border)",
                 color: apiKeyStatus === "ok" ? "#34c759" : "var(--text)",
-                cursor: !activeApiKey || apiKeyStatus === "testing" ? "not-allowed" : "pointer",
-                opacity: !activeApiKey || apiKeyStatus === "testing" ? 0.5 : 1,
+                cursor: !activeApiKey || apiKeyStatus === "testing" || (settings.provider === "custom" && !settings.custom_api_base_url.trim()) ? "not-allowed" : "pointer",
+                opacity: !activeApiKey || apiKeyStatus === "testing" || (settings.provider === "custom" && !settings.custom_api_base_url.trim()) ? 0.5 : 1,
               }}
             >
               {apiKeyStatus === "testing" ? "Testing..." : apiKeyStatus === "ok" ? "Connected" : "Test Connection"}
@@ -523,11 +745,54 @@ function App() {
           </div>
           <div>
             <label className="block text-xs mb-1" style={{ color: "var(--text-secondary)" }}>Model</label>
-            <select value={settings.model} onChange={(e) => setSettings({ ...settings, model: e.target.value })} className="w-full px-3 py-2 rounded-lg text-sm outline-none" style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}>
-              {(settings.provider === "gemini" ? GEMINI_MODELS : OPENAI_MODELS).map((m) => (
-                <option key={m.value} value={m.value}>{m.label}</option>
-              ))}
-            </select>
+            {settings.provider === "gemini" ? (
+              <select value={settings.model} onChange={(e) => setSettings({ ...settings, model: e.target.value })} className="w-full px-3 py-2 rounded-lg text-sm outline-none" style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}>
+                {GEMINI_MODELS.map((m) => (
+                  <option key={m.value} value={m.value}>{m.label}</option>
+                ))}
+              </select>
+            ) : settings.provider === "openai" ? (
+              <select value={settings.model} onChange={(e) => setSettings({ ...settings, model: e.target.value })} className="w-full px-3 py-2 rounded-lg text-sm outline-none" style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}>
+                {OPENAI_MODELS.map((m) => (
+                  <option key={m.value} value={m.value}>{m.label}</option>
+                ))}
+              </select>
+            ) : (
+              <>
+                <select
+                  value={OPENAI_COMPAT_MODEL_KNOWN.has(settings.model) ? settings.model : "__custom__"}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    setSettings({
+                      ...settings,
+                      model:
+                        v === "__custom__"
+                          ? OPENAI_COMPAT_MODEL_KNOWN.has(settings.model)
+                            ? ""
+                            : settings.model
+                          : v,
+                    });
+                  }}
+                  className="w-full px-3 py-2 rounded-lg text-sm outline-none mb-2"
+                  style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
+                >
+                  {OPENAI_COMPAT_MODEL_OPTIONS.map((m) => (
+                    <option key={m.value} value={m.value}>{m.label}</option>
+                  ))}
+                  <option value="__custom__">自定义模型名…</option>
+                </select>
+                {!OPENAI_COMPAT_MODEL_KNOWN.has(settings.model) && (
+                  <input
+                    type="text"
+                    value={settings.model}
+                    onChange={(e) => setSettings({ ...settings, model: e.target.value })}
+                    placeholder="e.g. my-model-id"
+                    className="w-full px-3 py-2 rounded-lg text-sm outline-none font-mono"
+                    style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--text)" }}
+                  />
+                )}
+              </>
+            )}
           </div>
           <div>
             <label className="block text-xs mb-1" style={{ color: "var(--text-secondary)" }}>Language</label>

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface AppSettings {
   provider: string;
   api_key: string;
   gemini_api_key: string;
+  /** OpenAI-compatible base URL (e.g. https://api.example.com/v1). Used when provider is `custom`. */
+  custom_api_base_url: string;
   model: string;
   language: string;
   shortcut: string;


### PR DESCRIPTION
- Add providers: Custom with configurable base URL (custom_api_base_url)

- DashScope compatible-mode: use chat/completions + input_audio; detect dashscope + compatible-mode in URL

- transcribe/validate/retry: route OpenAI multipart vs DashScope vs Gemini

- validate_api_key IPC: pass apiKey and customBaseUrl (Tauri camelCase)

- HTTP client: connect + request timeouts

- Onboarding: accessibility no longer blocks Get Started

- Custom UI: DashScope base URL preset dropdown; model select with Qwen3-ASR-Flash and custom entry

- gitignore: *.dmg build artifacts
